### PR TITLE
Typo in "fade in left/right big"

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -125,7 +125,7 @@ export const animationsList = [
 		value: 'fadeInRight'
 	},
 	{
-		label: __( 'Fade In Left Big' ),
+		label: __( 'Fade In Right Big' ),
 		value: 'fadeInRightBig'
 	},
 	{


### PR DESCRIPTION
On dropdown in Gutenberg block, you have "Fade In Left Big" twice. The second one should be "Fade In Right Big".